### PR TITLE
08 search copings

### DIFF
--- a/app/controllers/copings_controller.rb
+++ b/app/controllers/copings_controller.rb
@@ -1,5 +1,5 @@
 class CopingsController < ApplicationController
-  before_action :set_coping_list, only: %i[index new create show]
+  before_action :set_coping_list, only: %i[index new create show others copy]
 
   def index
     @copings = @coping_list.copings
@@ -20,6 +20,16 @@ class CopingsController < ApplicationController
 
   def show
     @coping = @coping_list.copings.find(params[:id])
+  end
+
+  def others
+    @other_copings = Coping.eager_load(coping_list: :user).where.not(user: { id: current_user.id }).where.not(status: 'close').sample(10)
+  end
+
+  def copy
+    @other_coping = Coping.find(params[:coping_id])
+    @coping = @coping_list.copings.build(coping_name: @other_coping.coping_name, cost_amount: @other_coping.cost_amount, time_amount: @other_coping.time_amount, emoji: @other_coping.emoji)
+    render :new
   end
 
   private

--- a/app/views/copings/new.html.erb
+++ b/app/views/copings/new.html.erb
@@ -1,6 +1,9 @@
 <h1>Copings#new</h1>
 <p>コーピング項目新規追加</p>
 
+<%= link_to '他の人のリストから選ぶ', others_coping_list_copings_path(@coping_list) %>
+<br />
+<br />
 <%= form_with model: @coping, url: coping_list_copings_path(@coping_list), local: true do |f| %>
 	<% if @coping.errors.present? %>
 		<ul>

--- a/app/views/copings/others.html.erb
+++ b/app/views/copings/others.html.erb
@@ -1,0 +1,8 @@
+<h1>Copings#others</h1>
+<p>他の人の項目から選ぶ</p>
+
+<% @other_copings.each do |coping_item|%>
+	<%= coping_item.emoji %><%= link_to coping_item.coping_name, copy_coping_list_copings_path(@coping_list, coping_id: coping_item.id) %><br/>
+	<%= "#{coping_item.time_amount}分 / #{coping_item.cost_amount}円" %><br/>
+	<br/>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   resources :coping_lists do
     resources :copings do
       resources :histories, only: %i[index new create show], shallow: true
+      get 'others', on: :collection
+      get 'copy', on: :collection
     end
     get 'histories', on: :member
   end


### PR DESCRIPTION
# 概要
新規でコーピング項目を追加する際に、自分以外が作成した項目でかつ公開設定となっているものを見ることができ、そこからコピーして新規項目が作成できるよう機能を追加しました。

# コメント
da36eb3d97494ddb18795899e8d4d70e789ed278：他人の項目を表示させる(others)、項目コピー(copy)のルーティングを設定しました。
9281d781482bc1456c2eb000e654cf7355e66117：上記2項目のアクションをコントローラーに追加しました。
b9a5bddd233eb87532ad37857a034e10bf5f81df：他人の項目表示画面を追加しました。