### PR TITLE
09 select copings

### DIFF
--- a/app/controllers/selections_controller.rb
+++ b/app/controllers/selections_controller.rb
@@ -1,0 +1,23 @@
+class SelectionsController < CopingsController
+  before_action :set_coping_list
+
+  def shuffle
+    @selected_copings = @coping_list.copings.sample(5)
+    render :select
+  end
+
+  def high_rate
+    high_rate_copings = Coping.joins(:histories).where(coping_list_id: @coping_list.id).group(:id).limit(5).order('average_evaluation desc').average(:evaluation).keys
+    @selected_copings = @coping_list.copings.find(high_rate_copings)
+    render :select
+  end
+
+  def never_done
+    @selected_copings = @coping_list.copings.left_joins(:histories).where(histories: { id: nil }).sample(5)
+    if @selected_copings.empty?
+      redirect_to shuffle_coping_list_copings_path(@coping_list), notice: 'すべて実行済みのため全項目からシャッフルしました'
+    else
+      render :select
+    end
+  end
+end

--- a/app/views/coping_lists/index.html.erb
+++ b/app/views/coping_lists/index.html.erb
@@ -2,7 +2,10 @@
 <p>コーピングリスト一覧</p>
 
 <%= link_to 'リスト新規作成', new_coping_list_path %>
-
+<br /><br />
 <% @coping_lists.each do |coping| %>
-	<h3><%= link_to coping.list_name, coping_list_copings_path(coping.id) %></h3>
+	<h4><%= link_to coping.list_name, coping_list_copings_path(coping) %></h4>
+	<%= link_to 'Shuffle', shuffle_coping_list_copings_path(coping) %> | 
+	<%= link_to 'Evaluation', high_late_coping_list_copings_path(coping) %> | 
+	<%= link_to 'Never', never_done_coping_list_copings_path(coping) %>
 <% end %>

--- a/app/views/copings/index.html.erb
+++ b/app/views/copings/index.html.erb
@@ -7,9 +7,8 @@
 <%= link_to 'このリストの履歴を見る', histories_coping_list_path(@coping_list) %><br/>
 <br/>
 <% @copings.each do |coping_item|%>
-	<%= coping_item.emoji %><%= link_to coping_item.coping_name, new_coping_list_coping_history_path(@coping_list, coping_item) %><br/>
-	<%= "#{coping_item.time_amount}分 / #{coping_item.cost_amount}円" %><br/>
-	<br/>
+	<%= coping_item.emoji %><%= link_to coping_item.coping_name, new_coping_list_coping_history_path(@coping_list, coping_item) %>
+	<%= "(#{coping_item.time_amount}分 / #{coping_item.cost_amount}円)" %><br/>
 <% end %>
-
+<br/>
 <%= link_to 'リスト一覧を見る', coping_lists_path %>

--- a/app/views/selections/select.html.erb
+++ b/app/views/selections/select.html.erb
@@ -1,0 +1,18 @@
+<h1>Selections#select</h1>
+<p>コーピング3択から選択</p>
+
+<h3><%= @coping_list.list_name %></h3>
+
+<% if action_name == 'shuffle' && @selected_copings.empty? %>
+    <%= link_to 'リスト新規作成', new_coping_list_path %><br/>
+    <p>まだ項目の登録がありません！</p><br/>
+<% end %>
+
+<% @selected_copings.each do |coping_item|%>
+	<%= coping_item.emoji %><%= link_to coping_item.coping_name, new_coping_list_coping_history_path(@coping_list, coping_item) %><br/>
+	<%= "#{coping_item.time_amount}分 / #{coping_item.cost_amount}円" %><br/>
+	<br/>
+<% end %>
+
+<%= link_to '別の方法でやり直す', select_coping_list_copings_path(@coping_list) %><br />
+<%= link_to 'リスト一覧を見る', coping_lists_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,8 +7,13 @@ Rails.application.routes.draw do
   resources :coping_lists do
     resources :copings do
       resources :histories, only: %i[index new create show], shallow: true
-      get 'others', on: :collection
-      get 'copy', on: :collection
+      collection do
+        get :others
+        get :copy
+        get '/shuffle', to: 'selections#shuffle'
+        get '/high_late', to: 'selections#high_rate'
+        get '/never_done', to: 'selections#never_done'
+      end
     end
     get 'histories', on: :member
   end


### PR DESCRIPTION
# 概要
コーピング項目を選ぶにあたり、リスト一覧表示だけでなく、下記の3つの方法から選択できるよう機能追加しました。
1. 全項目からシャッフルして表示
2. 評価の平均値の高い順に表示
3. 履歴がないものを表示

# コメント
f9b36d9622648de2286e378967fa919e6c5ef284：sectionsコントローラーを新規追加し、全項目からシャッフルして表示(shuffleアクション)・評価の平均値の高い順に表示(high_rateアクション)・履歴がないものを表示(never_doneアクション)を追加しました。
2fecbc9b97e67ef7a896825ea84f6f9975265a65：上記に対応するルーティングを追加しました。
89f2a34e7d20086ff236b2315fb8a855b8a70d30：上記に対応するコーピング項目表示方法の選択リンクを既存のビューファイルに追加、方法選択後の項目表示のビューファイルを追加しました。
71ba3e8f561f26f20205f7fe8b05934c81abc63d：コーピング項目一覧表示画面で2行にわたって項目内容が表示されていたものを1行に表示するよう修正しました。