### PR TITLE
12 attach css

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path
+      redirect_to login_path
     else
       render :new
     end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,3 +1,6 @@
 class History < ApplicationRecord
   belongs_to :coping
+
+  validates :change_amount, presence: true, numericality: { greater_than_or_equal_to: -100, less_than_or_equal_to: 100 }
+  validates :evaluation, presence: true, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 5 }
 end

--- a/app/views/coping_lists/histories.html.erb
+++ b/app/views/coping_lists/histories.html.erb
@@ -1,14 +1,29 @@
-<h1>Copings#histories</h1>
-<p>コーピングリストごとの履歴一覧</p>
+<div class="container mx-auto lg:w-3/5 p-2">
+	<h1 class="mt-8 text-2xl bold text-gray-700 text-center dark:text-white">評価履歴</h1>
+	<p class="mt-3 mb-6 text-sm text-center text-gray-600"><%= @coping_list.list_name %></p>
 
-<h3><%= @coping_list.list_name %></h3>
+	<% @histories.each do |history|%>
+		<div class="grid flex-wrap grid-cols-1 gap-3 my-3 mx-auto xl:mt-6">
+				<div class="w-full border border-yellow-300 dark:border-green-300 rounded-md">
+					<div class="p-2 bg-yellow-50">
+						<div class="flex items-end">
+							<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+								<path fill-rule="evenodd" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71V3.5z" clip-rule="evenodd" />
+							</svg>
+							<span class="text-gray-700 dark:text-gray-300"><%= history.created_at %></span>
+							<span class="ml-auto text-gray-700 dark:text-gray-300"><%= "評価:#{history.evaluation} / 変化:#{history.change_amount}" %></span>
+						</div>
+						<p class="text-gray-700 dark:text-gray-300"><%= "#{history.coping.emoji} #{history.coping.coping_name}" %></p>
+					</div>
 
-<% @histories.each do |history|%>
-	【<%= history.created_at %>】<br/>
-    <%= "#{history.coping.emoji} #{history.coping.coping_name}" %>
-	<%= "評価:#{history.evaluation} / 変化:#{history.change_amount}" %><br/>
-    <%= history.note %>
-	<br/><br/>
-<% end %>
-<br/>
-<%= link_to 'リスト一覧を見る', coping_list_copings_path(@coping_list) %>
+					<hr class="border-yellow-300 dark:border-gray-700">
+
+					<div class="p-2">
+						<p class=" text-gray-700 lg:text-md dark:text-white"><%= history.note %></p>
+					</div>
+				</div>
+		</div>
+	<% end %>
+	<%= link_to "#{@coping_list.list_name}一覧に戻る", coping_list_copings_path(@coping_list), class: 'inline-block w-full text-center mt-6 mb-3 text-md text-green-600 focus:outline-none focus:underline hover:underline' %>
+	<%= link_to 'コーピングリスト一覧に戻る', coping_lists_path, class: 'inline-block w-full text-center mt-3 mb-6 text-md text-green-600 focus:outline-none focus:underline hover:underline' %>
+</div>

--- a/app/views/coping_lists/index.html.erb
+++ b/app/views/coping_lists/index.html.erb
@@ -1,11 +1,58 @@
-<h1>CopingLists#index</h1>
-<p>コーピングリスト一覧</p>
+<div class="container mx-auto text-center p-2">
+	<div class="mx-auto lg:w-2/5">
+		<h1 class="my-8 text-2xl bold text-gray-700 text-center dark:text-white">コーピングリスト一覧</h1>
+	</div>
 
-<%= link_to 'リスト新規作成', new_coping_list_path %>
-<br /><br />
-<% @coping_lists.each do |coping| %>
-	<h4><%= link_to coping.list_name, coping_list_copings_path(coping) %></h4>
-	<%= link_to 'Shuffle', shuffle_coping_list_copings_path(coping) %> | 
-	<%= link_to 'Evaluation', high_late_coping_list_copings_path(coping) %> | 
-	<%= link_to 'Never', never_done_coping_list_copings_path(coping) %>
-<% end %>
+	<div class="grid grid-cols-1 gap-3 mt-8 xl:mt-12 xl:gap-5 lg:w-3/5 xl:w-2/5 lg:mx-auto">
+		<% @coping_lists.each do |coping| %>
+			<div class="p-3 space-y-1 border place-content-end border-green-200 bg-green-50 dark:border-green-300 rounded-md">
+				<div class="flex items-center">
+					<p class="inline-block text-lg ml-2 font-semibold text-green-600 dark:text-white">
+						<%= coping.list_name %>
+					</p>
+					<p class="inline-block ml-auto text-green-600">一覧</p>
+					<%= link_to coping_list_copings_path(coping), class: 'text-green-600 dark:bg-green-500 dark:text-white hover:underline hover:text-green-600 dark:hover:text-green-500' do %>
+						<svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 mr-2 hover:text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+						</svg>
+					<% end %>
+					<p class="inline-block text-green-600">履歴</p>
+					<%= link_to histories_coping_list_path(coping), class: 'text-green-600 dark:bg-green-500 dark:text-white hover:underline hover:text-green-600 dark:hover:text-green-500' do %>
+						<svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 mr-2 hover:text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+						</svg>
+					<% end %>
+				</div>
+				<hr class="h-px my-6 bg-gray-300 border-none">
+				<div class="w-auto overflow-hidden rounded-lg dark:bg-gray-800 dark:border-gray-700">
+					<div class="grid grid-cols-3 gap-x-1 justify-items-stretch mt-2 mx-2">
+						<%= link_to shuffle_coping_list_copings_path(coping) do %>
+							<button class="justify-center w-full px-2 py-1 text-white transition-colors duration-200 transform bg-green-500 rounded-md focus:outline-none sm:mx-1 hover:bg-green-600 focus:bg-green-500 focus:ring focus:ring-green-300 focus:ring-opacity-40">
+								<span class="mx-1">
+									シャッフル
+								</span>
+							</button>
+						<% end %>
+						
+						<%= link_to high_late_coping_list_copings_path(coping) do %>
+							<button class="justify-center w-full px-2 py-1 text-white transition-colors duration-200 transform bg-green-500 rounded-md focus:outline-none sm:mx-1 hover:bg-green-600 focus:bg-green-500 focus:ring focus:ring-green-300 focus:ring-opacity-40">
+								<span class="mx-1">
+									高評価順
+								</span>
+							</button>
+						<% end %>
+
+						<%= link_to never_done_coping_list_copings_path(coping) do %>
+							<button class="justify-center w-full px-2 py-1 text-white transition-colors duration-200 transform bg-green-500 rounded-md focus:outline-none sm:mx-1 hover:bg-green-600 focus:bg-green-500 focus:ring focus:ring-green-300 focus:ring-opacity-40">
+								<span class="mx-1">
+									未実施
+								</span>
+							</button>
+						<% end %>
+					</div>
+				</div>
+			</div>
+		<% end %>
+	</div>
+	<%= link_to 'リスト新規作成', new_coping_list_path, class:'inline-block text-center my-5 px-4 py-2 text-gray-600 transition-colors duration-200 transform bg-yellow-200 rounded-md hover:bg-yellow-300 focus:outline-none focus:bg-yellow-500 focus:ring focus:ring-yellow-400 focus:ring-opacity-50' %>
+</div>

--- a/app/views/coping_lists/new.html.erb
+++ b/app/views/coping_lists/new.html.erb
@@ -1,20 +1,27 @@
-<h1>CopingLists#new</h1>
-<p>コーピングリスト新規作成</p>
-
-<%= form_with model: @coping_list, local: true do |f| %>
-	<% if @coping_list.errors.present? %>
-		<ul>
-			<% @coping_list.errors.full_messages.each do |message| %>
-				<li><%= message %></li>
-			<% end %>
-		</ul>
-	<% end %>
-	<div class="form-group">
-		<%= f.label :list_name %><br />
-		<%= f.text_field :list_name %>
+<div class="container mx-auto lg:w-3/5">
+	<div class="mx-auto lg:w-3/5">
+		<h1 class="my-8 text-2xl bold text-gray-700 text-center dark:text-white">コーピングリスト<br />新規作成</h1>
 	</div>
-	<br />
-	<%= f.submit %>
-<% end %>
-</br>
-<%= link_to 'リスト一覧', coping_lists_path %>
+  	<!-- login form -->
+	<div class="mt-8 mb-5">
+		<%= form_with model: @coping_list, local: true do |f| %>
+			<% if @coping_list.errors.present? %>
+			<ul>
+				<% @coping_list.errors.full_messages.each do |message| %>
+					<li><%= message %></li>
+				<% end %>
+			</ul>
+			<% end %>
+
+			<div>
+				<%= f.label :list_name, class:'block mb-2 text-sm text-gray-600 dark:text-gray-200' %>
+				<%= f.text_field :list_name, class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
+
+			<div class="mt-6">
+				<%= f.submit '作成', class:'w-full px-4 py-2 tracking-wide text-gray-600 transition-colors duration-200 transform bg-yellow-200 rounded-md hover:bg-yellow-300 focus:outline-none focus:bg-yellow-500 focus:ring focus:ring-yellow-400 focus:ring-opacity-50' %>
+			</div>
+		<% end %>
+	</div>
+	<%= link_to 'リスト一覧へ戻る', coping_lists_path, class: 'flex items-center justify-center mb-10 text-green-600 focus:outline-none focus:underline hover:underline' %>
+</div>

--- a/app/views/copings/index.html.erb
+++ b/app/views/copings/index.html.erb
@@ -1,14 +1,30 @@
-<h1>Copings#index</h1>
-<p>コーピング項目一覧</p>
+<div class="container mx-auto lg:w-3/5 p-2">
+	<h1 class="my-8 text-2xl bold text-gray-700 text-center dark:text-white">コーピング一覧</h1>
 
-<h3><%= @coping_list.list_name %></h3>
+	<div class="w-full max-w-screen-xl mx-auto">
+		<div class="flex justify-center y-10">
+			<div class="w-full max-w-lg">
+				<div class="bg-green-50 shadow-md rounded-sm px-3 pt-2 pb-4 mb-3">
+					<div class="block text-green-700 text-center text-lg font-semibold py-1">
+						<%= @coping_list.list_name %>
+					</div>
+					<% @copings.each.with_index(1) do |coping_item, n|%>
+						<div class="flex justify-start border-b border-dotted text-green-700 rounded-md py-1 px-1">
+							<div class="flex-grow px-1 text-gray-700 cursor-pointer hover:text-green-700">
+								<%= "#{n}." %>
+								<%= link_to coping_item.coping_name, new_coping_list_coping_history_path(@coping_list, coping_item) %>
+							</div>
+							<div class="text-sm font-normal text-gray-500 tracking-wide"><%= "(#{coping_item.time_amount}分/#{coping_item.cost_amount}円)" %></div>
+							<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-300" fill="currentColor" class="bi bi-trash3" viewBox="0 0 16 16">
+  								<path d="M6.5 1h3a.5.5 0 0 1 .5.5v1H6v-1a.5.5 0 0 1 .5-.5ZM11 2.5v-1A1.5 1.5 0 0 0 9.5 0h-3A1.5 1.5 0 0 0 5 1.5v1H2.506a.58.58 0 0 0-.01 0H1.5a.5.5 0 0 0 0 1h.538l.853 10.66A2 2 0 0 0 4.885 16h6.23a2 2 0 0 0 1.994-1.84l.853-10.66h.538a.5.5 0 0 0 0-1h-.995a.59.59 0 0 0-.01 0H11Zm1.958 1-.846 10.58a1 1 0 0 1-.997.92h-6.23a1 1 0 0 1-.997-.92L3.042 3.5h9.916Zm-7.487 1a.5.5 0 0 1 .528.47l.5 8.5a.5.5 0 0 1-.998.06L5 5.03a.5.5 0 0 1 .47-.53Zm5.058 0a.5.5 0 0 1 .47.53l-.5 8.5a.5.5 0 1 1-.998-.06l.5-8.5a.5.5 0 0 1 .528-.47ZM8 4.5a.5.5 0 0 1 .5.5v8.5a.5.5 0 0 1-1 0V5a.5.5 0 0 1 .5-.5Z"/>
+							</svg>
+						</div>
+					<% end %>
+				</div>
+			</div>
+		</div>
+	</div>
 
-<%= link_to '項目新規追加', new_coping_list_coping_path(@coping_list) %><br/>
-<%= link_to 'このリストの履歴を見る', histories_coping_list_path(@coping_list) %><br/>
-<br/>
-<% @copings.each do |coping_item|%>
-	<%= coping_item.emoji %><%= link_to coping_item.coping_name, new_coping_list_coping_history_path(@coping_list, coping_item) %>
-	<%= "(#{coping_item.time_amount}分 / #{coping_item.cost_amount}円)" %><br/>
-<% end %>
-<br/>
-<%= link_to 'リスト一覧を見る', coping_lists_path %>
+	<%= link_to 'このリストにコーピングを追加する', new_coping_list_coping_path(@coping_list), class:'block mx-auto max-w-lg justify-self-center text-center my-5 px-4 py-2 text-gray-600 transition-colors duration-200 transform bg-yellow-200 rounded-md hover:bg-yellow-300 focus:outline-none focus:bg-yellow-500 focus:ring focus:ring-yellow-400 focus:ring-opacity-50' %>
+	<%= link_to 'リスト一覧に戻る', coping_lists_path, class: 'block mb-5 text-center text-green-700' %>
+</div>

--- a/app/views/copings/new.html.erb
+++ b/app/views/copings/new.html.erb
@@ -1,40 +1,59 @@
-<h1>Copings#new</h1>
-<p>コーピング項目新規追加</p>
+<div class="container mx-auto lg:w-3/5">
+	<h1 class="mt-8 text-2xl bold text-gray-700 text-center dark:text-white">コーピング登録</h1>
+	<p class="mt-2 text-sm text-center text-gray-600"><%= "- #{@coping_list.list_name} -" %></p>
 
-<%= link_to '他の人のリストから選ぶ', others_coping_list_copings_path(@coping_list) %>
-<br />
-<br />
-<%= form_with model: @coping, url: coping_list_copings_path(@coping_list), local: true do |f| %>
-	<% if @coping.errors.present? %>
-		<ul>
-			<% @coping.errors.full_messages.each do |message| %>
-				<li><%= message %></li>
-			<% end %>
-		</ul>
+	<%= link_to others_coping_list_copings_path(@coping_list), class: 'flex items-center justify-center text-sm my-4 hover:text-green-600 focus:outline-none focus:underline hover:underline' do %>
+		<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 font-semibold text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+			<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 9l3 3m0 0l-3 3m3-3H8m13 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+		</svg>
+		<span class="text-green-600">他の人の作成した項目から登録する</span>
 	<% end %>
-	<div class="form-group">
-		<%= f.label :coping_name %><br />
-		<%= f.text_field :coping_name %>
-	</div>
-	<div class="form-group">
-		<%= f.label :cost_amount %><br />
-		<%= f.text_field :cost_amount %>
-	</div>
-	<div class="form-group">
-		<%= f.label :time_amount %><br />
-		<%= f.text_field :time_amount %>
-	</div>
-	<div class="form-group">
-		<%= f.label :emoji %><br />
-		<%= f.text_field :emoji %>
-	</div>
-	<div class="form-group">
-		<%= f.label :status %><br />
-		<%= f.check_box :status, {}, 'close', 'open' %>
-	</div>
-	<br />
-	<%= f.submit %>
-<% end %>
-<br />
-<%= link_to "#{@coping_list.list_name}一覧に戻る", coping_list_copings_path(@coping_list) %>
+  	<!-- login form -->
+	<div class="mb-12">
+		<%= form_with model: @coping, url: coping_list_copings_path(@coping_list), local: true do |f| %>
+			<% if @coping.errors.present? %>
+				<ul>
+					<% @coping.errors.full_messages.each do |message| %>
+						<li><%= message %></li>
+					<% end %>
+				</ul>
+			<% end %>
+			<div>
+				<%= f.label :coping_name, class:'block mb-2 text-sm text-gray-600 dark:text-gray-200' %>
+				<%= f.text_field :coping_name, class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
 
+			<div class="mt-6">
+				<%= f.label :cost_amount, class:'block mb-2 text-sm text-gray-600 dark:text-gray-200' %>
+				<%= f.text_field :cost_amount, class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
+
+			<div class="mt-6">
+				<div class="flex justify-between mb-2">
+					<%= f.label :time_amount, class: 'text-sm text-gray-600 dark:text-gray-200' %>
+				</div>
+				<%= f.text_field :time_amount, class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
+
+			<div class="mt-6">
+				<div class="flex justify-between mb-2">
+					<%= f.label :emoji, class: 'text-sm text-gray-600 dark:text-gray-200' %>
+				</div>
+				<%= f.text_field :emoji, class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
+
+			<div class="mt-6">
+				<div class="flex justify-between mb-2">
+					<%= f.label :status, class: 'text-sm text-gray-600 dark:text-gray-200' %>
+				</div>
+				<%= f.check_box :status, {}, 'close', 'open' %>
+			</div>
+
+			<div class="mt-6">
+				<%= f.submit '登録', class:'w-full px-4 py-2 tracking-wide text-gray-600 transition-colors duration-200 transform bg-yellow-200 rounded-md hover:bg-yellow-300 focus:outline-none focus:bg-yellow-500 focus:ring focus:ring-yellow-400 focus:ring-opacity-50' %>
+			</div>
+
+		<% end %>
+		<%= link_to "#{@coping_list.list_name}一覧に戻る", coping_list_copings_path(@coping_list), class: 'flex items-center justify-center mt-6 mb-10 text-sm text-green-600 focus:outline-none focus:underline hover:underline' %>
+	</div>
+</div>

--- a/app/views/copings/others.html.erb
+++ b/app/views/copings/others.html.erb
@@ -1,8 +1,32 @@
-<h1>Copings#others</h1>
-<p>他の人の項目から選ぶ</p>
+<div class="container mx-auto xl:w-4/5">
+	<div class="mx-auto lg:w-3/5">
+		<h1 class="mt-8 mb-4 text-2xl bold text-gray-700 text-center dark:text-white">他の人の作成した<br />項目から登録する</h1>
+		<%= link_to others_coping_list_copings_path(@coping_list), class: 'flex items-center justify-center text-sm mb-2 hover:text-green-600 focus:outline-none focus:underline hover:underline' do %>
+			<svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 font-semibold text-green-600" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16">
+			<path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/>
+			<path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/>
+			</svg>
+			<span class="text-green-600">シャッフルする</span>
+		<% end %>
+	</div>
 
-<% @other_copings.each do |coping_item|%>
-	<%= coping_item.emoji %><%= link_to coping_item.coping_name, copy_coping_list_copings_path(@coping_list, coping_id: coping_item.id) %><br/>
-	<%= "#{coping_item.time_amount}分 / #{coping_item.cost_amount}円" %><br/>
-	<br/>
-<% end %>
+	<div class="grid flex-wrap grid-cols-1 gap-3 my-8 xl:mt-12 xl:gap-4 lg:grid-cols-2">
+		<% @other_copings.each do |coping_item|%>
+			<%= link_to copy_coping_list_copings_path(@coping_list, coping_id: coping_item.id), class: 'p-0 text-green-600 capitalize transition-colors duration-200 transform dark:bg-green-500 dark:text-white hover:text-green-600 dark:hover:text-green-500' do %>
+				<div class="w-full p-2 space-y-1 border-2 border-green-200 bg-green-50 hover:bg-green-100 dark:border-green-300 rounded-md">
+					<h2 class="text-center text-xl font-semibold text-green-600 capitalize dark:text-white">
+						<%= "#{coping_item.emoji} #{coping_item.coping_name}" %>
+					</h2>
+					<hr class="h-px my-6 bg-gray-300 border-none">
+					<p class="mt-6 text-sm text-center text-gray-400"><%= "#{coping_item.time_amount}分 / #{coping_item.cost_amount}円" %></p>
+				</div>
+			<% end %>
+		<% end %>
+	</div>
+
+		<div class="mx-auto lg:w-3/5">
+			<%= link_to '自分で新しく項目をを登録する', new_coping_list_coping_path(@coping_list), class:'flex place-item-center items-center justify-center my-4 px-4 py-2 text-gray-600 transition-colors duration-200 transform bg-yellow-200 rounded-md hover:bg-yellow-300 focus:outline-none focus:bg-yellow-500 focus:ring focus:ring-yellow-400 focus:ring-opacity-50' %>
+		</div>
+
+	<%= link_to "コーピングリスト一覧に戻る", coping_lists_path, class: 'flex w-auto items-center justify-center mt-6 mb-10 text-md text-green-600 focus:outline-none focus:underline hover:underline' %>
+</div>

--- a/app/views/histories/index.html.erb
+++ b/app/views/histories/index.html.erb
@@ -1,16 +1,30 @@
-<h1>Histories#index</h1>
-<p>コーピング項目の評価履歴一覧</p>
+<div class="container mx-auto lg:w-3/5 p-2">
+	<h1 class="mt-8 text-2xl bold text-gray-700 text-center dark:text-white">評価履歴</h1>
+	<p class="mt-2 text-sm text-center text-gray-600"><%= @coping_list.list_name %></p>
+	<hr>
+	<p class="mb-4 text-sm text-center text-gray-600"><%= @coping.coping_name %></p>
 
-<h3><%= @coping_list.list_name %></h3>
-<h4><%= @coping.coping_name %></h4>
+	<% @histories.each do |history|%>
+		<div class="grid flex-wrap grid-cols-1 gap-3 my-3 mx-auto xl:mt-6">
+				<div class="w-full border border-yellow-300 dark:border-green-300 rounded-md">
+					<div class="p-2 bg-yellow-50">
+						<div class="flex items-end">
+							<svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+								<path fill-rule="evenodd" d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71V3.5z" clip-rule="evenodd" />
+							</svg>
+							<span class="text-gray-700 dark:text-gray-300"><%= history.created_at %></span>
+							<span class="ml-auto text-gray-700 dark:text-gray-300"><%= "評価:#{history.evaluation} / 変化:#{history.change_amount}" %></span>
+						</div>
+					</div>
 
-<% @histories.each do |history|%>
-	<%= history.created_at %><br/>
-	<%= "評価:#{history.evaluation} / 変化:#{history.change_amount}" %><br/>
-    <%= history.note %>
-	<br/>
-<% end %>
-<br/>
+					<hr class="border-yellow-300 dark:border-gray-700">
 
-<%= link_to 'このリストの項目一覧を見る', coping_list_copings_path(@coping_list) %><br/>
-<%= link_to 'このリストの履歴一覧を見る', histories_coping_list_path(@coping_list) %>
+					<div class="p-2">
+						<p class=" text-gray-700 lg:text-md dark:text-white"><%= history.note %></p>
+					</div>
+				</div>
+		</div>
+	<% end %>
+	<%= link_to "#{@coping_list.list_name}の評価履歴一覧", histories_coping_list_path(@coping_list), class: 'inline-block w-full text-center mt-6 text-md text-green-600 focus:outline-none focus:underline hover:underline' %>
+	<%= link_to "#{@coping_list.list_name}一覧に戻る", coping_list_copings_path(@coping_list), class: 'inline-block w-full text-center mt-6 mb-10 text-md text-green-600 focus:outline-none focus:underline hover:underline' %>
+</div>

--- a/app/views/histories/new.html.erb
+++ b/app/views/histories/new.html.erb
@@ -1,29 +1,51 @@
-<h1>Histories#new</h1>
-<p>コーピング項目の評価新規作成</p>
+<div class="container mx-auto lg:w-3/5">
+	<h1 class="mt-8 text-2xl bold text-gray-700 text-center dark:text-white">評価登録</h1>
+	<p class="mt-2 text-sm text-center text-gray-600"><%= "- #{@coping.coping_name} -" %></p>
 
-<h3><%= @coping.coping_name %></h3>
-<%= form_with model: [@coping_list, @coping, @history], local: true do |f| %>
-	<% if @history.errors.present? %>
-		<ul>
-			<% @history.errors.full_messages.each do |message| %>
-				<li><%= message %></li>
+  	<!-- history form -->
+	<div class="mb-12">
+		<%= form_with model: [@coping_list, @coping, @history], local: true do |f| %>
+			<% if @history.errors.present? %>
+				<ul>
+					<% @history.errors.full_messages.each do |message| %>
+						<li><%= message %></li>
+					<% end %>
+				</ul>
 			<% end %>
-		</ul>
-	<% end %>
-	<div class="form-group">
-		<%= f.label :change_amount %><br />
-		<%= f.number_field :change_amount, min: -100, max: 100 %>
+			<div>
+				<%= f.label :change_amount, class:'block mb-2 text-sm text-gray-600 dark:text-gray-200' %>
+				<%= f.range_field :change_amount, in: -100..100, step: 1, class: 'form-range cursor-pointer appearance-none w-full h-3 p-0 bg-yellow-100 focus:outline-none focus:ring-0 focus:shadow-none' %>
+				<div class="flex justify-between">
+					<div class="text-sm text-gray-700 -ml-1 bottom-0 -mb-4">-100</div>
+					<div class="text-sm text-gray-700 -mr-1 bottom-0 -mb-4">0</div>
+					<div class="text-sm text-gray-700 -mr-1 bottom-0 -mb-4">+100</div>
+				</div>
+			</div>
+
+			<div class="mt-8">
+				<%= f.label :evaluation, class:'block mb-2 text-sm text-gray-600 dark:text-gray-200' %>
+				<%= f.range_field :evaluation, in: 1..5, step: 0.5, class: 'form-range cursor-pointer appearance-none w-full h-3 p-0 bg-yellow-100 focus:outline-none focus:ring-0 focus:shadow-none' %>
+				<div class="flex justify-between">
+					<div class="text-sm text-gray-700 -ml-1 bottom-0 -mb-4">1</div>
+					<div class="text-sm text-gray-700 -mr-1 bottom-0 -mb-4">2</div>
+					<div class="text-sm text-gray-700 -mr-1 bottom-0 -mb-4">3</div>
+					<div class="text-sm text-gray-700 -mr-1 bottom-0 -mb-4">4</div>
+					<div class="text-sm text-gray-700 -mr-1 bottom-0 -mb-4">5</div>
+				</div>
+			</div>
+
+			<div class="mt-6">
+				<div class="flex justify-between mb-2">
+					<%= f.label :note, class: 'text-sm text-gray-600 dark:text-gray-200' %>
+				</div>
+				<%= f.text_area :note, class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
+
+			<div class="mt-6">
+				<%= f.submit '記録', class:'w-full px-4 py-2 tracking-wide text-gray-600 transition-colors duration-200 transform bg-yellow-200 rounded-md hover:bg-yellow-300 focus:outline-none focus:bg-yellow-500 focus:ring focus:ring-yellow-400 focus:ring-opacity-50' %>
+			</div>
+
+		<% end %>
+		<%= link_to "#{@coping_list.list_name}一覧に戻る", coping_list_copings_path(@coping_list), class: 'flex items-center justify-center mt-6 mb-10 text-sm text-green-600 focus:outline-none focus:underline hover:underline' %>
 	</div>
-    <div class="form-group">
-		<%= f.label :evaluation %><br />
-		<%= f.number_field :evaluation, min: 1, max: 5 %>
-	</div>
-    <div class="form-group">
-		<%= f.label :note %><br />
-		<%= f.text_area :note %>
-	</div>
-	<br />
-	<%= f.submit %>
-<% end %>
-</br>
-<%= link_to 'リスト一覧', coping_lists_path %>
+</div>

--- a/app/views/selections/select.html.erb
+++ b/app/views/selections/select.html.erb
@@ -1,17 +1,29 @@
-<h1>Selections#select</h1>
-<p>コーピング3択から選択</p>
+<div class="container mx-auto xl:w-4/5">
+	<div class="mx-auto lg:w-3/5">
+		<h1 class="my-8 text-2xl bold text-gray-700 text-center dark:text-white">コーピング選択</h1>
+	</div>
 
-<h3><%= @coping_list.list_name %></h3>
+	<div class="grid flex-wrap grid-cols-1 gap-3 my-8 xl:mt-12 xl:gap-4 lg:grid-cols-2">
+		<% @selected_copings.each do |coping_item|%>
+			<%= link_to new_coping_list_coping_history_path(@coping_list, coping_item), class: 'p-0 text-green-600 capitalize transition-colors duration-200 transform dark:bg-green-500 dark:text-white hover:text-green-600 dark:hover:text-green-500' do %>
+				<div class="w-full p-2 space-y-1 border-2 border-green-200 bg-green-50 hover:bg-green-100 dark:border-green-300 rounded-md">
+					<h2 class="text-center text-xl font-semibold text-green-600 capitalize dark:text-white">
+						<%= "#{coping_item.emoji} #{coping_item.coping_name}" %>
+					</h2>
+					<hr class="h-px my-6 bg-gray-300 border-none">
+					<p class="mt-6 text-sm text-center text-gray-400"><%= "#{coping_item.time_amount}分 / #{coping_item.cost_amount}円" %></p>
+				</div>
+			<% end %>
+		<% end %>
+	</div>
 
-<% if action_name == 'shuffle' && @selected_copings.empty? %>
-    <%= link_to 'リスト新規作成', new_coping_list_path %><br/>
-    <p>まだ項目の登録がありません！</p><br/>
-<% end %>
-
-<% @selected_copings.each do |coping_item|%>
-	<%= coping_item.emoji %><%= link_to coping_item.coping_name, new_coping_list_coping_history_path(@coping_list, coping_item) %><br/>
-	<%= "#{coping_item.time_amount}分 / #{coping_item.cost_amount}円" %><br/>
-	<br/>
-<% end %>
-
-<%= link_to 'リスト一覧を見る', coping_lists_path %>
+	<% if action_name == 'shuffle' && @selected_copings.empty? %>
+		<div class="mx-auto lg:w-3/5">
+			<p class="my-2 text-center text-gray-700">まだ項目の登録がありません。</p>
+			<p class="mt-2 mb-10 text-center text-gray-700">新しくコーピングを登録しましょう！</p>
+			<%= link_to '新しく項目をを登録する', new_coping_list_coping_path(@coping_list), class:'flex place-item-center items-center justify-center my-4 px-4 py-2 text-gray-600 transition-colors duration-200 transform bg-yellow-200 rounded-md hover:bg-yellow-300 focus:outline-none focus:bg-yellow-500 focus:ring focus:ring-yellow-400 focus:ring-opacity-50' %>
+			<%= link_to '他の人の作成した項目から登録する', others_coping_list_copings_path(@coping_list), class:'flex place-item-center items-center justify-center my-2 px-4 py-2 text-gray-600 transition-colors duration-200 transform bg-yellow-200 rounded-md hover:bg-yellow-300 focus:outline-none focus:bg-yellow-500 focus:ring focus:ring-yellow-400 focus:ring-opacity-50' %>
+		</div>
+	<% end %>
+	<%= link_to "コーピングリスト一覧に戻る", coping_lists_path, class: 'flex w-auto items-center justify-center mt-6 mb-10 text-md text-green-600 focus:outline-none focus:underline hover:underline' %>
+</div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,15 +1,27 @@
-<h1>UserSessions#new</h1>
-<p>ユーザーログイン</p>
+<div class="container mx-auto lg:w-3/5">
+	<h1 class="my-8 lg:my-16 text-2xl bold text-gray-700 text-center dark:text-white">ログイン</h1>
+  	<!-- login form -->
+	<div class="my-10 lg:my-24">
+		<%= form_with url: login_path, local: true do |f| %>
+			<div class="mt-3">
+				<%= f.label :email, class:'block mb-2 text-sm text-gray-600 dark:text-gray-200' %>
+				<%= f.text_field :email, placeholder: 'example@example.com', class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
 
-<%= form_with url: login_path, local: true do |f| %>
+			<div class="mt-6">
+				<div class="flex justify-between mb-2">
+					<%= f.label :password, class: 'text-sm text-gray-600 dark:text-gray-200' %>
+					<a href="#" class="text-sm text-gray-400 hover:text-yellow-500 hover:underline">パスワードリセット</a>
+				</div>
+				<%= f.password_field :password, placeholder: 'こちらにパスワードを入力', class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
+
+			<div class="mt-6">
+				<%= f.submit 'ログイン', class:'w-full px-4 py-2 tracking-wide text-gray-600 transition-colors duration-200 transform bg-yellow-200 rounded-md hover:bg-yellow-300 focus:outline-none focus:bg-yellow-500 focus:ring focus:ring-yellow-400 focus:ring-opacity-50' %>
+			</div>
+
+		<% end %>
+
+		<p class="mt-6 text-sm text-center text-gray-400">アカウントをお持ちでない方は <%= link_to 'ユーザー登録', new_user_path, class: 'text-green-600 focus:outline-none focus:underline hover:underline' %></p>
 	</div>
-	<div class="form-group">
-		<%= f.label :email %><br />
-		<%= f.text_field :email %>
-	</div>
-	<div class="form-group">
-		<%= f.label :password %><br />
-		<%= f.password_field :password %>
-	</div>
-	<%= f.submit %>
-<% end %>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,30 +1,38 @@
-<h1>Users#new</h1>
-<p>ユーザー登録</p>
+<div class="container mx-auto lg:w-3/5">
+	<h1 class="my-8 text-2xl bold text-gray-700 text-center dark:text-white">ユーザー新規登録</h1>
+  	<!-- login form -->
+	<div class="mb-32">
+		<%= form_with model: @user, local: true do |f| %>
+			<div class="mt-3">
+				<%= f.label :name, class:'block mb-2 text-sm text-gray-600 dark:text-gray-200' %>
+				<%= f.text_field :name, class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
 
-<%= form_with model: @user, local: true do |f| %>
-	<% if @user.errors.present? %>
-		<ul>
-			<% @user.errors.full_messages.each do |message| %>
-				<li><%= message %></li>
-			<% end %>
-		</ul>
-	<% end %>
-	<div class="form-group">
-		<%= f.label :name %><br />
-		<%= f.text_field :name %>
+			<div class="mt-6">
+				<%= f.label :email, class:'block mb-2 text-sm text-gray-600 dark:text-gray-200' %>
+				<%= f.text_field :email, placeholder: 'example@example.com', class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
+
+			<div class="mt-6">
+				<div class="flex justify-between mb-2">
+					<%= f.label :password, class: 'text-sm text-gray-600 dark:text-gray-200' %>
+				</div>
+				<%= f.password_field :password, placeholder: 'こちらにパスワードを入力', class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
+
+			<div class="mt-6">
+				<div class="flex justify-between mb-2">
+					<%= f.label :password_confirmation, class: 'text-sm text-gray-600 dark:text-gray-200' %>
+				</div>
+				<%= f.password_field :password_confirmation, placeholder: 'こちらにパスワード(確認用)を入力', class: 'block w-full px-4 py-2 mt-2 text-gray-700 placeholder-gray-400 bg-white border border-gray-200 rounded-md dark:placeholder-gray-600 dark:bg-gray-900 dark:text-gray-300 dark:border-gray-700 focus:border-yellow-400 dark:focus:border-yellow-400 focus:ring-yellow-400 focus:outline-none focus:ring focus:ring-opacity-40' %>
+			</div>
+
+			<div class="mt-6">
+				<%= f.submit '登録', class:'w-full px-4 py-2 tracking-wide text-gray-600 transition-colors duration-200 transform bg-yellow-200 rounded-md hover:bg-yellow-300 focus:outline-none focus:bg-yellow-500 focus:ring focus:ring-yellow-400 focus:ring-opacity-50' %>
+			</div>
+
+		<% end %>
+
+		<p class="mt-6 text-sm text-center text-gray-400">アカウントをお持ちの方は <%= link_to 'ログイン', login_path, class: 'text-green-600 focus:outline-none focus:underline hover:underline' %>
 	</div>
-	<div class="form-group">
-		<%= f.label :email %><br />
-		<%= f.text_field :email %>
-	</div>
-	<div class="form-group">
-		<%= f.label :password %><br />
-		<%= f.password_field :password %>
-	</div>
-	<div class="form-group">
-		<%= f.label :password_confirmation %><br />
-		<%= f.password_field :password_confirmation %>
-	</div>
-	<br />
-	<%= f.submit %>
-<% end %>
+</div>


### PR DESCRIPTION
# 概要
TailwindCSSを用いて、各ビューファイルにデザインを適用させました。スマートフォンでの使用を想定していますが、タブレット・PC画面でも操作した際に違和感がない程度にレスポンスシブ対応も行いました。

# コメント
下記コミットにてそれぞれデザインを適用させました。
09d376b3f3241a8aea276e3a104dbde978ac16ad：ユーザー登録・ログインページ
e4a02ac71c4136adf5f315b6150ecc1dccca02c3：コーピングリスト
b87407048eb5b1db71dd34f53c407b905edbc5cd：コーピング項目
a982195b1c8e93dc0228261bde0e517ba37c7fa2：コーピング評価

1124c3174fb21dd477a3b0bfc431846917c5d175：登録後のリダイレクト先をログイン画面に変更しました。ログイン未済のユーザーに対するログイン画面遷移等の処理は今後追加予定です。
c2959435a833c0d8b1769892301a7cd3ef9caf38：気分変化量と評価についてのバリデーション設定漏れがあったため追加しました。