### PR TITLE
17 improve functions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :require_login
+
+  private
+
+  def not_authenticated
+    redirect_to login_url, alert: t('defaults.message.not_authenticated')
+  end
 end

--- a/app/controllers/coping_lists_controller.rb
+++ b/app/controllers/coping_lists_controller.rb
@@ -1,5 +1,5 @@
 class CopingListsController < ApplicationController
-  before_action :set_coping_list, only: %i[edit destroy histories]
+  before_action :set_coping_list, only: %i[edit update destroy histories]
 
   def index
     @coping_lists = current_user.coping_lists
@@ -20,6 +20,14 @@ class CopingListsController < ApplicationController
   end
 
   def edit; end
+
+  def update
+    if @coping_list.update(coping_list_params)
+      redirect_to(coping_lists_url, notice: t('defaults.message.updated', item: CopingList.model_name.human))
+    else
+      render :edit
+    end
+  end
 
   def destroy
     @coping_list.destroy

--- a/app/controllers/selections_controller.rb
+++ b/app/controllers/selections_controller.rb
@@ -8,15 +8,21 @@ class SelectionsController < CopingsController
   end
 
   # 履歴より評価値の平均値を計算、平均値の高い順に5つコーピング項目を抽出する
+  # 抽出されたものがなかった場合は全項目からシャッフルする処理へリダイレクトする
   def high_rate
-    high_rate_copings = Coping.joins(:histories).where(coping_list_id: @coping_list.id).group(:id).limit(5).order('average_evaluation desc').average(:evaluation).keys
+    high_rate_copings = Coping.high_avarage_rate(@coping_list).keys
     @selected_copings = @coping_list.copings.find(high_rate_copings)
-    render :select
+    if @selected_copings.empty?
+      redirect_to shuffle_coping_list_copings_path(@coping_list), notice: '履歴がないため全項目からランダムで表示しました'
+    else
+      render :select
+    end
   end
 
   # 履歴がひとつもないコーピング項目から5つランダムで抽出する
+  # 抽出されたものがなかった場合は全項目からシャッフルする処理へリダイレクトする
   def never_done
-    @selected_copings = @coping_list.copings.left_joins(:histories).where(histories: { id: nil }).sample(5)
+    @selected_copings = @coping_list.copings.no_histories
     if @selected_copings.empty?
       redirect_to shuffle_coping_list_copings_path(@coping_list), notice: '全て実行済みのため全項目からランダムで表示しました'
     else

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,3 +1,6 @@
 class StaticPagesController < ApplicationController
+  skip_before_action :require_login
+
   def top; end
+
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,4 +1,6 @@
 class UserSessionsController < ApplicationController
+  skip_before_action :require_login
+
   def new
     @user = User.new
   end
@@ -7,7 +9,7 @@ class UserSessionsController < ApplicationController
     @user = login(params[:email], params[:password])
 
     if @user
-      redirect_back_or_to(root_url, notice: t('.login_success'))
+      redirect_back_or_to(coping_lists_path, notice: t('.login_success'))
     else
       flash[:alert] = t('.login_failed')
       render :new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  skip_before_action :require_login
+
   def new
     @user = User.new
   end

--- a/app/models/coping.rb
+++ b/app/models/coping.rb
@@ -3,8 +3,11 @@ class Coping < ApplicationRecord
   has_many :histories, dependent: :destroy
 
   validates :coping_name, presence: true
-  validates :emoji, presence: true
+  validates :emoji, presence: true, format: { with: /[\p{Emoji}\p{Emoji_Component}&&[:^ascii:]]/, message: "のみ使えます(※一部使用できないものがあります)" }, length: { maximum: 3 }
   validates :status, presence: true
 
   enum status: { open: 0, close: 1 }
+
+  scope :high_avarage_rate, ->(coping_list) { joins(:histories).where(coping_list_id: coping_list.id).group(:id).limit(5).order('average_evaluation desc').average(:evaluation) }
+  scope :no_histories, -> { left_joins(:histories).where(histories: { id: nil }).sample(5) }
 end


### PR DESCRIPTION
# 概要
サーバーサイドでの処理について、下記の通り修正・改良しました。

8a7a6eea3bdf29232efa21fc87ce63f3947edda0：コーピング編集処理のアクション内容を追加
8da60cbb3be772fe2bbd2c742afc9c774823f5b5：コーピング項目の`emoji`カラムに対するバリデーションを追加
3cde9ce02f07e14c614a91613a6dc804e25be016：ログイン未済のユーザーがログイン後に使用できるページにアクセスできないよう`not_authenticated`コールバックを追加・ログイン後のリダイレクト先をコーピングリスト一覧ページに修正

# コメント
`emoji`カラムに対するバリデーションについて、絵文字かつ1文字のみのバリデーション設定が望ましいのですが、現状一部の絵文字(数字や記号を含んだ絵文字・人や顔が写っている絵文字(人数・性別などバリエーションがあるもの))が1文字扱いとならないため、バリデーションは最大3文字まで許可しています。そのため、絵文字を最大で3文字まで入力できるような仕様となっています。