### PR TITLE
Fix: アナリティクスの結果が反映されないためGoogle site tagを修正

### DIFF
--- a/app/views/shared/_google_analytics.html.erb
+++ b/app/views/shared/_google_analytics.html.erb
@@ -6,7 +6,4 @@
   gtag('js', new Date());
 
   gtag('config', 'G-TC5XG8TTJ2');
-  if (#{raw current_user.to_json}) {
-    gtag('set', {'user_id': #{raw current_user.to_json}.id});
-  }
 </script>


### PR DESCRIPTION
# 概要
Google Analytics上でアクセスデータが反映しないため、Google site tagの記述を修正しました。